### PR TITLE
Align Group.Stats properly for 32-bit platforms.

### DIFF
--- a/groupcache.go
+++ b/groupcache.go
@@ -166,6 +166,8 @@ type Group struct {
 	// concurrent callers.
 	loadGroup flightGroup
 
+	_ int32 // force Stats to be 8-byte aligned on 32-bit platforms
+
 	// Stats are statistics on the group.
 	Stats Stats
 }

--- a/groupcache_test.go
+++ b/groupcache_test.go
@@ -27,6 +27,7 @@ import (
 	"sync"
 	"testing"
 	"time"
+	"unsafe"
 
 	"github.com/golang/protobuf/proto"
 
@@ -440,6 +441,14 @@ func TestNoDedup(t *testing.T) {
 	const wantBytes = int64(len(testkey) + len(testval))
 	if g.mainCache.nbytes != wantBytes {
 		t.Errorf("cache has %d bytes, want %d", g.mainCache.nbytes, wantBytes)
+	}
+}
+
+func TestGroupStatsAlignment(t *testing.T) {
+	var g Group
+	off := unsafe.Offsetof(g.Stats)
+	if off%8 != 0 {
+		t.Fatal("Stats structure is not 8-byte aligned.")
 	}
 }
 


### PR DESCRIPTION
Fixes golang/go#18334